### PR TITLE
Fix build error in markdown-to-json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gulp-watch": "^4.3.10",
     "jade": "^1.11.0",
     "lodash": "^4.16.4",
+    "marked": "^0.3.6",
     "run-sequence": "^1.2.2",
     "through2": "^2.0.1"
   },

--- a/postfile.js
+++ b/postfile.js
@@ -15,6 +15,7 @@ var util           = require('gulp-util');
 var _              = require('lodash');
 var runSequence    = require('run-sequence');
 var through        = require('through2');
+var mkd            = require('marked');
 
 // configs
 var blogConfig = require('./blogconfig.json', 'utf8');
@@ -260,7 +261,7 @@ gulp.task('build:json:posts', function(callback) {
   return gulp.src(devConfig.src + 'md/post/*.md')
     .pipe(plumber())
     .pipe(util.buffer())
-    .pipe(markdown2Json('posts.json'))
+    .pipe(markdown2Json(mkd, 'posts.json'))
     .pipe(through.obj(function (file, enc, callback) {
       //バッファから文字列に変化させてJSONに戻す
       var posts = JSON.parse(String(file.contents));
@@ -288,7 +289,7 @@ gulp.task('build:json:demos', function(callback) {
   return gulp.src(devConfig.src + 'md/demo/page/*.md')
     .pipe(plumber())
     .pipe(util.buffer())
-    .pipe(markdown2Json('demos.json'))
+    .pipe(markdown2Json(mkd, 'demos.json'))
     .pipe(through.obj(function (file, enc, callback) {
       //バッファから文字列に変化させてJSONに戻す
       var demos = JSON.parse(String(file.contents));


### PR DESCRIPTION
set renderer(marked) to first argument before output name of markdown2Json();

ref: #37 

```
% npm run archives

> dskd-v5@5.4.0 archives /Users/tkg/Sandbox/dskd
> gulp build:html --gulpfile postfile.js

[15:40:54] Using gulpfile ~/Sandbox/dskd/postfile.js
[15:40:54] Starting 'build:html'...
[15:40:54] Starting 'build:html:post'...
[15:40:54] Starting 'build:json:posts'...
[15:40:55] Finished 'build:json:posts' after 168 ms
[15:40:55] Starting 'build:post:page'...
[15:40:55] Starting 'build:post:archives'...
[15:40:55] Starting 'build:post:index'...
[15:40:56] Finished 'build:post:index' after 1.34 s
[15:40:59] Finished 'build:post:archives' after 4.04 s
[15:41:00] Finished 'build:post:page' after 5.1 s
[15:41:00] Starting 'build:post:feed'...
[15:41:00] Finished 'build:post:feed' after 52 ms
[15:41:00] Finished 'build:html:post' after 5.33 s
[15:41:00] Starting 'build:html:demo'...
[15:41:00] Starting 'build:json:demos'...
[15:41:00] Finished 'build:json:demos' after 55 ms
[15:41:00] Starting 'build:demo:page'...
[15:41:00] Starting 'build:demo:index'...
[15:41:00] Finished 'build:demo:index' after 135 ms
[15:41:00] Finished 'build:demo:page' after 304 ms
[15:41:00] Finished 'build:html:demo' after 361 ms
[15:41:00] Finished 'build:html' after 5.69 s
```

without error!
